### PR TITLE
Ensure we pass file paths as wide strings on windows

### DIFF
--- a/src/delimited_index.cc
+++ b/src/delimited_index.cc
@@ -17,6 +17,8 @@
 #include "r_utils.h"
 #endif
 
+#include "unicode_fopen.h"
+
 using namespace vroom;
 
 delimited_index::delimited_index(
@@ -47,7 +49,7 @@ delimited_index::delimited_index(
       delim_len_(0) {
 
   std::error_code error;
-  mmap_ = mio::make_mmap_source(filename, error);
+  mmap_ = make_mmap_source(filename, error);
 
   if (error) {
     // We cannot actually portably compare error messages due to a bug in

--- a/src/delimited_index_connection.cc
+++ b/src/delimited_index_connection.cc
@@ -13,6 +13,8 @@
 #include "spdlog/spdlog.h"
 #endif
 
+#include "unicode_fopen.h"
+
 using namespace vroom;
 
 delimited_index_connection::delimited_index_connection(
@@ -41,7 +43,7 @@ delimited_index_connection::delimited_index_connection(
   filename_ = Rcpp::as<std::string>(Rcpp::as<Rcpp::Function>(
       Rcpp::Environment::namespace_env("vroom")["vroom_tempfile"])());
 
-  std::FILE* out = std::fopen(filename_.c_str(), "wb");
+  std::FILE* out = unicode_fopen(filename_.c_str(), "wb");
 
   auto con = R_GetConnection(in);
 
@@ -220,7 +222,7 @@ delimited_index_connection::delimited_index_connection(
   }
 
   std::error_code error;
-  mmap_ = mio::make_mmap_source(filename_, error);
+  mmap_ = make_mmap_source(filename_, error);
   if (error) {
     throw Rcpp::exception(error.message().c_str(), false);
   }

--- a/src/fixed_width_index.h
+++ b/src/fixed_width_index.h
@@ -26,6 +26,8 @@
 #include "spdlog/spdlog.h"
 #endif
 
+#include "unicode_fopen.h"
+
 namespace vroom {
 
 class fixed_width_index
@@ -54,7 +56,7 @@ public:
       : col_starts_(col_starts), col_ends_(col_ends), trim_ws_(trim_ws) {
 
     std::error_code error;
-    mmap_ = mio::make_mmap_source(filename, error);
+    mmap_ = make_mmap_source(filename, error);
 
     if (error) {
       // We cannot actually portably compare error messages due to a bug in

--- a/src/fixed_width_index_connection.cc
+++ b/src/fixed_width_index_connection.cc
@@ -15,6 +15,8 @@
 
 #include <array>
 
+#include "unicode_fopen.h"
+
 using namespace vroom;
 
 fixed_width_index_connection::fixed_width_index_connection(
@@ -35,7 +37,7 @@ fixed_width_index_connection::fixed_width_index_connection(
   filename_ = Rcpp::as<std::string>(Rcpp::as<Rcpp::Function>(
       Rcpp::Environment::namespace_env("vroom")["vroom_tempfile"])());
 
-  std::FILE* out = std::fopen(filename_.c_str(), "wb");
+  std::FILE* out = unicode_fopen(filename_.c_str(), "wb");
 
   auto con = R_GetConnection(in);
 
@@ -130,7 +132,7 @@ fixed_width_index_connection::fixed_width_index_connection(
   }
 
   std::error_code error;
-  mmap_ = mio::make_mmap_source(filename_, error);
+  mmap_ = make_mmap_source(filename_, error);
   if (error) {
     throw Rcpp::exception(error.message().c_str(), false);
   }

--- a/src/unicode_fopen.h
+++ b/src/unicode_fopen.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <stdio.h>
+// clang-format off
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wsign-compare"
+#include <mio/shared_mmap.hpp>
+# pragma clang diagnostic pop
+#else
+#include <mio/shared_mmap.hpp>
+#endif
+// clang-format on
+
+#ifdef _WIN32
+#include <Rinternals.h>
+#include <windows.h>
+#endif
+
+// This is needed to support wide character paths on windows
+inline FILE* unicode_fopen(const char* path, const char* mode) {
+  FILE* out;
+#ifdef _WIN32
+  // First conver the mode to the wide equivalent
+  // Only usage is 2 characters so max 8 bytes + 2 byte null.
+  wchar_t mode_w[10];
+  MultiByteToWideChar(CP_UTF8, 0, mode, -1, mode_w, 9);
+
+  // Then convert the path
+  wchar_t* buf;
+  size_t len = MultiByteToWideChar(CP_UTF8, 0, path, -1, NULL, 0);
+  if (len <= 0) {
+    Rf_error("Cannot convert file to Unicode: %s", path);
+  }
+  buf = (wchar_t*)R_alloc(len, sizeof(wchar_t));
+  if (buf == NULL) {
+    Rf_error("Could not allocate buffer of size: %ll", len);
+  }
+
+  MultiByteToWideChar(CP_UTF8, 0, path, -1, buf, len);
+  out = _wfopen(buf, mode_w);
+#else
+  out = fopen(path, mode);
+#endif
+
+  return out;
+}
+
+inline mio::mmap_source
+make_mmap_source(const char* file, std::error_code& error) {
+#ifdef __WIN32
+  wchar_t* buf;
+  size_t len = MultiByteToWideChar(CP_UTF8, 0, file, -1, NULL, 0);
+  if (len <= 0) {
+    Rf_error("Cannot convert file to Unicode: %s", file);
+  }
+  buf = (wchar_t*)malloc(len * sizeof(wchar_t));
+  if (buf == NULL) {
+    Rf_error("Could not allocate buffer of size: %ll", len);
+  }
+
+  MultiByteToWideChar(CP_UTF8, 0, file, -1, buf, len);
+  mio::mmap_source out = mio::make_mmap_source(buf, error);
+  free(buf);
+  return out;
+#else
+  return mio::make_mmap_source(file, error);
+#endif
+}

--- a/src/vroom.cc
+++ b/src/vroom.cc
@@ -9,6 +9,8 @@
 #include <Rcpp.h>
 #include <algorithm>
 
+#include "unicode_fopen.h"
+
 using namespace Rcpp;
 
 // [[Rcpp::export]]
@@ -78,7 +80,7 @@ SEXP vroom_(
 
 // [[Rcpp::export]]
 bool has_trailing_newline(CharacterVector filename) {
-  std::FILE* f = std::fopen(CHAR(filename[0]), "rb");
+  std::FILE* f = unicode_fopen(CHAR(filename[0]), "rb");
 
   if (!f) {
     return true;

--- a/src/vroom_fwf.cc
+++ b/src/vroom_fwf.cc
@@ -4,6 +4,8 @@
 
 #include "LocaleInfo.h"
 
+#include "unicode_fopen.h"
+
 using namespace Rcpp;
 
 // [[Rcpp::export]]
@@ -90,7 +92,7 @@ List whitespace_columns_(
     std::string filename, size_t skip, ptrdiff_t n, std::string comment) {
 
   std::error_code error;
-  auto mmap = mio::make_mmap_source(filename, error);
+  auto mmap = make_mmap_source(filename, error);
   if (error) {
     // We cannot actually portably compare error messages due to a bug in
     // libstdc++ (https://stackoverflow.com/a/54316671/2055486), so just print

--- a/src/vroom_write.cc
+++ b/src/vroom_write.cc
@@ -8,6 +8,8 @@
 #include "connection.h"
 #include "r_utils.h"
 
+#include "unicode_fopen.h"
+
 typedef enum {
   quote_needed = 1,
   quote_all = 2,
@@ -316,7 +318,7 @@ void vroom_write_(
     strcpy(mode, "ab");
   }
 
-  std::FILE* out = std::fopen(filename.c_str(), mode);
+  std::FILE* out = unicode_fopen(filename.c_str(), mode);
   if (!out) {
     std::string msg("Cannot open file for writing:\n* ");
     msg += '\'' + filename + '\'';


### PR DESCRIPTION
When using either fopen or mio we need to use wide strings on windows to
properly handle file paths with unicode characters.

Fixes #221